### PR TITLE
Update regex generation and scanning

### DIFF
--- a/TinyPG/Compiler/TerminalSymbol.cs
+++ b/TinyPG/Compiler/TerminalSymbol.cs
@@ -28,28 +28,28 @@ namespace TinyPG.Compiler
         {
             Name = name;
 
-            // The pattern is a lot faster if the Regex starts on a caret,
-            // as per PR #4:  Since the scanner throws away any matches
-            // that don't start at index zero anyway, there is no logical
-            // difference between having the caret and not having it - just
+            // The pattern is a lot faster if the Regex starts on a \G anchor,
+            // as per PR #5:  Since the scanner throws away any matches
+            // that don't start at startpos anyway, there is no logical
+            // difference between having the anchor and not having it - just
             // a speed difference.  BUT, be careful to only insert that
-            // caret if the value in the grammar file was actually a string
+            // anchor if the value in the grammar file was actually a string
             // literal rather than a bit of code or a variable identifier
             // containing the pattern:
             int insertIndex = -1; // negative value is a flag indicating don't insert anything.
-            string patternWithCaret = pattern;
+            string patternWithAnchor = pattern;
             if (pattern.StartsWith("@\"") && pattern.EndsWith("\"")) // string literal starting with @"
                 insertIndex = 2;
             else if (pattern.StartsWith("\"") && pattern.EndsWith("\"")) // string literal starting with "
                 insertIndex = 1;
             // If we are in a quote string of some sort, and it doesn't already start with an opening
-            // caret, add one and protect it with non-capturing grouping parentheses:
-            if (insertIndex >= 0 && pattern[insertIndex] != '^')
+            // anchor, add one and protect it with non-capturing grouping parentheses:
+            if (insertIndex >= 0 && pattern.IndexOf("\\G") != insertIndex)
             {
-                patternWithCaret = pattern.Insert(insertIndex, "^(?:");
-                patternWithCaret = patternWithCaret.Insert(patternWithCaret.Length - 1, ")");
+                patternWithAnchor = pattern.Insert(insertIndex, "\\G(?:");
+                patternWithAnchor = patternWithAnchor.Insert(patternWithAnchor.Length - 1, ")");
             }
-            Expression = new Regex(patternWithCaret, RegexOptions.Compiled);
+            Expression = new Regex(patternWithAnchor, RegexOptions.Compiled);
         }
 
         public TerminalSymbol(string name, Regex expression)

--- a/TinyPG/Templates/C#/Scanner.cs
+++ b/TinyPG/Templates/C#/Scanner.cs
@@ -117,15 +117,15 @@ namespace <%Namespace%>
 
                 int len = -1;
                 TokenType index = (TokenType)int.MaxValue;
-                string input = LowerInput.Substring(startpos);
 
                 tok = new Token(startpos, endpos);
 
                 for (i = 0; i < scantokens.Count; i++)
                 {
                     Regex r = Patterns[scantokens[i]];
-                    Match m = r.Match(input);
-                    if (m.Success && m.Index == 0 && ((m.Length > len) || (scantokens[i] < index && m.Length == len )))
+                    // use startpos instead of a substring to save memory allocation, but anchors must use \G in place of ^
+                    Match m = r.Match(LowerInput, startpos);
+                    if (m.Success && m.Index == startpos && ((m.Length > len) || (scantokens[i] < index && m.Length == len )))
                     {
                         len = m.Length;
                         index = scantokens[i];  


### PR DESCRIPTION
Fixes #3

TerminalSymbol.cs
* Update Regex pattern to use "\G" anchor in place of "^"
* "\G" matches the start position of the string, rather than the
beginning of the string.
* For some reason Mono appears to be applying "^" as if multi line mode
was turned on even though it isn't, which caused large files with many
lines to take significant time to scan

Scanner.cs
* Update template to perform regex scans using "startpos" instead of
creating a new substring
* This saves memory allocation and pairs perfectly with the "\G" anchor